### PR TITLE
Add Feet-to-meters and Fathoms-to-meters

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@
     // TEMPERATURES
     // Celcius
     CELCIUS_IN_KELVIN: 273.15,
+    // Length
+    METER_IN_FEET: 3.2808,
+    METER_IN_FATHOM: 0.5468,
   };
 
   function checksum(sentencePart) {
@@ -144,7 +147,14 @@
     if (inputFormat == 'k') {
       if (outputFormat == 'c') return value - utils.RATIOS.CELCIUS_IN_KELVIN;
     }
+    // LENGTH
+    if (inputFormat == 'ft') {
+      if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FEET;
+    }
 
+    if (inputFormat == 'fa') {
+      if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FATHOM;
+    }
     // Just return input if input/output formats are not recognised.
     return value;
   };

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,6 +1,6 @@
-var chai    = require("chai");
-var expect  = chai.expect;
-var utils   = require('../index');
+var chai   = require("chai");
+var expect = chai.expect;
+var utils  = require('../index');
 
 describe('Transform', function() {
   it('KM -> NM', function(done) {
@@ -118,18 +118,33 @@ describe('Transform', function() {
     expect(value).to.equal(57.295779578552306);
     done();
   });
-  
+
   it('CELCIUS -> KELVIN', function(done) {
     var value = utils.transform(0, 'c', 'k');
     expect(value).to.be.a('number');
     expect(value).to.equal(273.15);
     done();
-});
-  
+  });
+
   it('KELVIN -> CELCIUS', function(done) {
     var value = utils.transform(0, 'k', 'c');
     expect(value).to.be.a('number');
     expect(value).to.equal(-273.15);
     done()
   });
+
+  it('FEET -> METERS', function(done) {
+    var value = utils.transform(33, 'ft', 'm');
+    expect(value).to.be.a('number');
+    expect(value).to.equal(10.05852231163131);
+    done()
+  });
+
+  it('FATHOMS -> METERS', function(done) {
+    var value = utils.transform(10, 'fa', 'm');
+    expect(value).to.be.a('number');
+    expect(value).to.equal(18.288222384784202);
+    done()
+  });
+
 });


### PR DESCRIPTION
Add functionality to convert feet and fathoms to meters.

Would be needed for a PR to Signalk/signalk-parser-nmea0183, to support DBT, DBK and DBS sentences which does not list meters, only feet or fathoms.