### PR TITLE
ci: add GitHub Actions workflow and remove .travis.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run prettier:check
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - 'lts/*'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` running `npm ci`, `npm run prettier:check`, and `npm test` on a matrix of Node 22.x and 24.x. Triggers on push to `master` and on pull requests.
- Removes `.travis.yml`. Travis has not produced a build for this repository in a long time; GitHub Actions replaces it.

## Motivation

There are currently two open dependabot PRs bumping `mocha` from 2.5.3 to 11.x (#24, #25). Without CI, there is no automated signal that a dependency upgrade still builds and passes tests. This workflow closes that gap so future bumps (and contributions in general) can be verified before merge.

## Verification

Ran the workflow steps locally against three states:

| State | `npm ci` | `prettier:check` | `npm test` |
|---|---|---|---|
| current `master` | pass | clean | 51 passing |
| #25 head (`dependabot/.../multi-4afa144cf6`) | pass | clean | 51 passing |
| #24 head (`dependabot/.../multi-dc284cb219`) | pass | clean | 51 passing |

The workflow was also test-run in the fork msallin/nmea0183-utilities and passed on both Node 22.x and 24.x.

Mocha 11 requires Node >= 18.18; the matrix targets current LTS (22) and current (24) releases.