### PR TITLE
ci: add release_on_tag and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -14,15 +14,15 @@ jobs:
     steps:
       - name: Build Changelog
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: ${{ steps.github_release.outputs.changelog }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -16,7 +16,7 @@ jobs:
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -25,4 +25,4 @@ jobs:
           name: ${{ github.ref_name }}
           body: ${{ steps.github_release.outputs.changelog }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -1,0 +1,28 @@
+name: 'Release on tag'
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.github_release.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: 'fix, feature, doc, chore, test, ignore, other, dependencies'


### PR DESCRIPTION
Adds the two-step release/publish flow used by the sibling plugin repos (\`signalk-derived-data\`, \`nmea0183-signalk\`, \`signalk-to-nmea0183\`, ...) so releases of \`@signalk/nmea0183-utilities\` can be cut from a pushed tag instead of manually.

## Summary
- \`.github/workflows/release_on_tag.yml\` — on any pushed tag, builds a changelog from merged PRs and creates a GitHub Release.
- \`.github/workflows/publish.yml\` — on \`release: created\`, runs \`npm install && npm publish --access public\` on Node 22.x with OIDC (\`id-token: write\`) and \`NODE_AUTH_TOKEN\`.

The family's \`publish.yml\` files all contain a \`steps.vars.outputs.tag\` reference that was never defined, which makes the beta branch dead code. I deliberately left the beta branching out here \u2014 this package does not publish betas today, so plain \`npm publish --access public\` is simpler and correct. Easy to reinstate later if beta releases are needed.

## Required repository secrets
- \`NPM_TOKEN\` \u2014 same as other SignalK publishing repos
- \`RELEASE_PAT\` \u2014 used by the changelog builder + create-release step

## Test plan
- [x] YAML syntax validated locally
- [ ] Maintainer confirms \`NPM_TOKEN\` and \`RELEASE_PAT\` are configured on the repo
- [ ] First tag push after merge produces a GitHub Release and an npm publish