### PR TITLE
fix(transform): correct Kelvin <-> Fahrenheit conversion and add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,13 @@
 
     if (inputFormat == 'k') {
       if (outputFormat == 'c') return value - utils.RATIOS.CELCIUS_IN_KELVIN
-      if (outputFormat == 'f') return 1.8 * (value - 273) + 32
+      if (outputFormat == 'f')
+        return (value - utils.RATIOS.CELCIUS_IN_KELVIN) * 1.8 + 32
+    }
+
+    if (inputFormat == 'f') {
+      if (outputFormat == 'k')
+        return (value - 32) / 1.8 + utils.RATIOS.CELCIUS_IN_KELVIN
     }
     // LENGTH
     if (inputFormat == 'ft') {

--- a/test/transform.js
+++ b/test/transform.js
@@ -133,6 +133,53 @@ describe('Transform', function () {
     done()
   })
 
+  // Kelvin <-> Fahrenheit, using the three well-known fixed points so
+  // the coefficient, offset, and direction are all pinned:
+  //   0 K       = -459.67 F  (absolute zero)
+  //   273.15 K  =  32 F      (water freezes)
+  //   373.15 K  = 212 F      (water boils at 1 atm)
+  it('KELVIN -> FAHRENHEIT (absolute zero)', function (done) {
+    var value = utils.transform(0, 'k', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(-459.67, 1e-9)
+    done()
+  })
+
+  it('KELVIN -> FAHRENHEIT (water freezing)', function (done) {
+    var value = utils.transform(273.15, 'k', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(32, 1e-9)
+    done()
+  })
+
+  it('KELVIN -> FAHRENHEIT (water boiling)', function (done) {
+    var value = utils.transform(373.15, 'k', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(212, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> KELVIN (absolute zero)', function (done) {
+    var value = utils.transform(-459.67, 'f', 'k')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(0, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> KELVIN (water freezing)', function (done) {
+    var value = utils.transform(32, 'f', 'k')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(273.15, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> KELVIN (water boiling)', function (done) {
+    var value = utils.transform(212, 'f', 'k')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(373.15, 1e-9)
+    done()
+  })
+
   it('FEET -> METERS', function (done) {
     var value = utils.transform(33, 'ft', 'm')
     expect(value).to.be.a('number')


### PR DESCRIPTION
Closes #15.

## Review of the existing Kelvin -> Fahrenheit conversion

The Kelvin -> Fahrenheit conversion added in #16 (merged March 2024) is:

\`\`\`js
if (outputFormat == 'f') return 1.8 * (value - 273) + 32
\`\`\`

Two issues:

1. **Wrong constant.** It hardcodes \`273\` instead of using the existing \`utils.RATIOS.CELCIUS_IN_KELVIN\` (\`273.15\`). Same file, same API — the sibling \`k -> c\` line uses the named constant. As a result:
    - \`0 K -> -459.4 F\` (this PR): instead of the correct \`-459.67 F\` (absolute zero)
    - Every other temperature reads 0.27 F colder than it should be
2. **No inverse conversion.** Every other temperature direction is bidirectional (\`c <-> k\`), but there's no \`f -> k\`.
3. **No tests.** PR #16 was \`+1 -0 (1 files)\`, no test coverage. \`test/transform.js\` has tests for every other conversion but skipped this one.

## What this PR does

- Switches the \`k -> f\` path to use \`utils.RATIOS.CELCIUS_IN_KELVIN\` so it's consistent with the sibling \`k -> c\` path and numerically correct.
- Adds the inverse \`f -> k\` using the same named constant.
- Adds six tests in \`test/transform.js\`, three per direction, pinned to three well-known fixed points so the coefficient, offset, and direction are all locked in:

| Kelvin | Fahrenheit | |
|---|---|---|
| 0 | -459.67 | absolute zero |
| 273.15 | 32 | water freezes |
| 373.15 | 212 | water boils at 1 atm |

## Test plan

- [x] \`npm run prettier:check\` clean
- [x] \`npm test\` — all 57 tests pass locally (was 51, added 6)
- [ ] CI green on Node 22.x and 24.x