### PR TITLE
ci: bump release actions to node24 runtimes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
       - name: Build Changelog
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v5
+        uses: mikepenz/release-changelog-builder-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- mikepenz/release-changelog-builder-action@v5 → @v6
- softprops/action-gh-release@v2 → @v3

Both majors drop the Node 20 runtime (deprecated on GitHub Actions, being removed September 16, 2026) and move to Node 24. No API changes; existing step inputs/outputs in publish.yml are unaffected.

Noticed during the v0.10.0 release — the publish run surfaced the Node 20 deprecation warning for both actions.

## Test plan

- [x] YAML parses
- [x] Diff is only the two `uses:` lines
- [ ] Next tagged release succeeds (will verify when the first tag is cut after merge)