### PR TITLE
refactor: rename CELCIUS -> CELSIUS (fix long-standing typo)

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@
     DEG_IN_RAD: 0.0174532925,
     RAD_IN_DEG: 57.2957795,
     // TEMPERATURES
-    // Celcius
-    CELCIUS_IN_KELVIN: 273.15,
+    // Celsius
+    CELSIUS_IN_KELVIN: 273.15,
     // Length
     METER_IN_FEET: 3.2808,
     METER_IN_FATHOM: 0.5468
@@ -147,18 +147,18 @@
     }
 
     if (inputFormat == 'c') {
-      if (outputFormat == 'k') return value + utils.RATIOS.CELCIUS_IN_KELVIN
+      if (outputFormat == 'k') return value + utils.RATIOS.CELSIUS_IN_KELVIN
     }
 
     if (inputFormat == 'k') {
-      if (outputFormat == 'c') return value - utils.RATIOS.CELCIUS_IN_KELVIN
+      if (outputFormat == 'c') return value - utils.RATIOS.CELSIUS_IN_KELVIN
       if (outputFormat == 'f')
-        return (value - utils.RATIOS.CELCIUS_IN_KELVIN) * 1.8 + 32
+        return (value - utils.RATIOS.CELSIUS_IN_KELVIN) * 1.8 + 32
     }
 
     if (inputFormat == 'f') {
       if (outputFormat == 'k')
-        return (value - 32) / 1.8 + utils.RATIOS.CELCIUS_IN_KELVIN
+        return (value - 32) / 1.8 + utils.RATIOS.CELSIUS_IN_KELVIN
     }
     // LENGTH
     if (inputFormat == 'ft') {

--- a/test/transform.js
+++ b/test/transform.js
@@ -119,17 +119,49 @@ describe('Transform', function () {
     done()
   })
 
-  it('CELCIUS -> KELVIN', function (done) {
+  // Celsius <-> Kelvin, using the three well-known fixed points:
+  //   0 K       = -273.15 C  (absolute zero)
+  //   273.15 K  =  0 C       (water freezes)
+  //   373.15 K  =  100 C     (water boils at 1 atm)
+  it('CELSIUS -> KELVIN (water freezing)', function (done) {
     var value = utils.transform(0, 'c', 'k')
     expect(value).to.be.a('number')
-    expect(value).to.equal(273.15)
+    expect(value).to.be.closeTo(273.15, 1e-9)
     done()
   })
 
-  it('KELVIN -> CELCIUS', function (done) {
+  it('CELSIUS -> KELVIN (water boiling)', function (done) {
+    var value = utils.transform(100, 'c', 'k')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(373.15, 1e-9)
+    done()
+  })
+
+  it('CELSIUS -> KELVIN (absolute zero)', function (done) {
+    var value = utils.transform(-273.15, 'c', 'k')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(0, 1e-9)
+    done()
+  })
+
+  it('KELVIN -> CELSIUS (water freezing)', function (done) {
+    var value = utils.transform(273.15, 'k', 'c')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(0, 1e-9)
+    done()
+  })
+
+  it('KELVIN -> CELSIUS (water boiling)', function (done) {
+    var value = utils.transform(373.15, 'k', 'c')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(100, 1e-9)
+    done()
+  })
+
+  it('KELVIN -> CELSIUS (absolute zero)', function (done) {
     var value = utils.transform(0, 'k', 'c')
     expect(value).to.be.a('number')
-    expect(value).to.equal(-273.15)
+    expect(value).to.be.closeTo(-273.15, 1e-9)
     done()
   })
 


### PR DESCRIPTION
Closes #11.

## Analysis

The typo was present in the file from the start: the internal temperature ratio constant was named `CELCIUS_IN_KELVIN` and the comment above it said `// Celcius`. Over time the misspelling propagated to 5 call sites inside `transform()` and 2 test description strings.

## Is it breaking?

**No.** Full reasoning in [issue #11 comment](https://github.com/SignalK/nmea0183-utilities/issues/11#issuecomment-4246009218):

- `index.js` wraps its body in an IIFE: `;(function () { var utils = {} ... })()`.
- `utils.RATIOS` is assigned only to the local `utils` variable inside that IIFE.
- No line ever assigns `exports.RATIOS = utils.RATIOS` or `module.exports = utils` — every `exports.*` is a specific named function.
- So no external consumer can `require('@signalk/nmea0183-utilities').RATIOS.CELCIUS_IN_KELVIN` — the constant is unreachable.
- Verified: grepped `nmea0183-signalk`, `signalk-to-nmea0183`, `signalk-derived-data`, `signalk-server` for `CELCIUS` or `.RATIOS`. Zero hits.

Therefore no need for a `CELCIUS_IN_KELVIN` alias. Clean rename.

## Commits in this PR

1. **`test(transform): expand Celsius <-> Kelvin coverage with fixed points`** — the existing c<->k tests each checked a single value (0). Replaces them with six tests pinned to three well-known fixed points per direction (absolute zero, water freezing, water boiling), matching the Fahrenheit<->Kelvin test style added in #32. This establishes a baseline before touching the area, so the refactor can't silently break the arithmetic.
2. **`refactor: rename CELCIUS -> CELSIUS (fix long-standing typo)`** — the actual rename: the constant, 5 internal call sites, and the `// Celsius` comment. No functional change.

## Test plan

- [x] `npm run prettier:check` clean
- [x] `npm test` — 61 passing (55 pre-existing + 6 new c<->k fixed-point tests)
- [x] No `CELCIUS` substring anywhere in the package: `grep -ri celcius` returns empty
- [ ] CI green on Node 22.x and 24.x