### PR TITLE
fix: add missing transform conversions and throw on unknown pairs

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,12 +101,21 @@
     // KM
     if (inputFormat == 'km') {
       if (outputFormat == 'nm') return value / utils.RATIOS.NM_IN_KM
+      if (outputFormat == 'm') return value * 1000
     }
 
     // NM
     if (inputFormat == 'nm') {
       if (outputFormat == 'km') return value / utils.RATIOS.KM_IN_NM
       if (outputFormat == 'm') return (value * 1000) / utils.RATIOS.KM_IN_NM
+    }
+
+    // M
+    if (inputFormat == 'm') {
+      if (outputFormat == 'km') return value / 1000
+      if (outputFormat == 'nm') return (value / 1000) * utils.RATIOS.KM_IN_NM
+      if (outputFormat == 'ft') return value * utils.RATIOS.METER_IN_FEET
+      if (outputFormat == 'fa') return value * utils.RATIOS.METER_IN_FATHOM
     }
 
     // KNOTS
@@ -146,8 +155,10 @@
       if (outputFormat == 'deg') return value / utils.RATIOS.DEG_IN_RAD
     }
 
+    // TEMPERATURE
     if (inputFormat == 'c') {
       if (outputFormat == 'k') return value + utils.RATIOS.CELSIUS_IN_KELVIN
+      if (outputFormat == 'f') return value * 1.8 + 32
     }
 
     if (inputFormat == 'k') {
@@ -157,9 +168,11 @@
     }
 
     if (inputFormat == 'f') {
+      if (outputFormat == 'c') return (value - 32) / 1.8
       if (outputFormat == 'k')
         return (value - 32) / 1.8 + utils.RATIOS.CELSIUS_IN_KELVIN
     }
+
     // LENGTH
     if (inputFormat == 'ft') {
       if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FEET
@@ -168,8 +181,10 @@
     if (inputFormat == 'fa') {
       if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FATHOM
     }
-    // Just return input if input/output formats are not recognised.
-    return value
+
+    throw new Error(
+      'unsupported conversion: ' + inputFormat + ' -> ' + outputFormat
+    )
   }
 
   exports.magneticVariaton = function (degrees, pole) {

--- a/test/transform.js
+++ b/test/transform.js
@@ -225,4 +225,88 @@ describe('Transform', function () {
     expect(value).to.equal(18.288222384784202)
     done()
   })
+
+  // Celsius <-> Fahrenheit (previously missing — transform silently
+  // returned the input unchanged).
+  it('CELSIUS -> FAHRENHEIT (water freezing)', function (done) {
+    var value = utils.transform(0, 'c', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(32, 1e-9)
+    done()
+  })
+
+  it('CELSIUS -> FAHRENHEIT (water boiling)', function (done) {
+    var value = utils.transform(100, 'c', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(212, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> CELSIUS (water freezing)', function (done) {
+    var value = utils.transform(32, 'f', 'c')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(0, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> CELSIUS (water boiling)', function (done) {
+    var value = utils.transform(212, 'f', 'c')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(100, 1e-9)
+    done()
+  })
+
+  // Distance base-unit pairs that were missing.
+  it('KM -> M', function (done) {
+    expect(utils.transform(1, 'km', 'm')).to.equal(1000)
+    done()
+  })
+
+  it('M -> KM', function (done) {
+    expect(utils.transform(1000, 'm', 'km')).to.equal(1)
+    done()
+  })
+
+  it('M -> NM', function (done) {
+    var value = utils.transform(1852, 'm', 'nm')
+    expect(value).to.be.closeTo(1, 1e-6)
+    done()
+  })
+
+  // Length: the inverse of the existing ft -> m / fa -> m pairs.
+  it('METERS -> FEET', function (done) {
+    var value = utils.transform(1, 'm', 'ft')
+    expect(value).to.be.closeTo(3.2808, 1e-4)
+    done()
+  })
+
+  it('METERS -> FATHOMS', function (done) {
+    var value = utils.transform(1, 'm', 'fa')
+    expect(value).to.be.closeTo(0.5468, 1e-4)
+    done()
+  })
+
+  // Unknown conversions must fail loudly. Previously transform silently
+  // returned the input for any unrecognised pair, giving callers wrong
+  // values with no signal.
+  it('throws on unknown input unit', function (done) {
+    expect(function () {
+      utils.transform(1, 'furlong', 'm')
+    }).to.throw(/unsupported conversion/i)
+    done()
+  })
+
+  it('throws on unknown output unit', function (done) {
+    expect(function () {
+      utils.transform(1, 'm', 'furlong')
+    }).to.throw(/unsupported conversion/i)
+    done()
+  })
+
+  it('throws on typo (kmh instead of kph)', function (done) {
+    expect(function () {
+      utils.transform(10, 'knots', 'kmh')
+    }).to.throw(/unsupported conversion/i)
+    done()
+  })
 })


### PR DESCRIPTION
## Summary

The conversion matrix in \`utils.transform\` is asymmetric and falls back to \`return value\` silently for any unsupported pair. This gives callers wrong output with no signal.

Verified on current master:

\`\`\`
transform(50,   'c',  'f')  -> 50      // C->F missing
transform(50,   'f',  'c')  -> 50      // F->C missing
transform(100,  'km', 'm')  -> 100     // km->m missing
transform(1000, 'm',  'km') -> 1000    // m->anything missing
transform(1,    'm',  'ft') -> 1       // m->ft missing
transform(10,   'knots', 'kmh') -> 10  // typo, silent pass-through
\`\`\`

## Changes

Two things that go together:

1. **Fill in the missing pairs.** C<->F, km<->m, m<->nm, m<->ft, m<->fa. The existing cascade is preserved structurally.
2. **Throw on unknown pairs.** Replace the silent \`return value\` fallback with \`throw new Error('unsupported conversion: ...')\`. A caller who mistypes a unit string now fails loudly instead of getting wrong output.

Item 2 is a behavior change. None of the SignalK consumers I checked depend on the silent pass-through (they all pass known unit strings from NMEA parsing code), but it warrants a minor version bump on next release.

## Test plan

- [x] 12 new tests, all fail on master and pass on this branch
- [x] \`npm test\` — 73 passing (+12 new)
- [x] \`npm run prettier:check\` — clean