### PR TITLE
fix: int/float return 0 instead of NaN for unparseable input

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,8 @@ exports.int = function (n) {
   if (('' + n).trim() === '') {
     return 0
   }
-  return parseInt(n, 10)
+  const parsed = parseInt(n, 10)
+  return Number.isNaN(parsed) ? 0 : parsed
 }
 
 exports.integer = function (n) {
@@ -260,7 +261,8 @@ exports.float = function (n) {
   if (('' + n).trim() === '') {
     return 0.0
   }
-  return parseFloat(n)
+  const parsed = parseFloat(n)
+  return Number.isNaN(parsed) ? 0.0 : parsed
 }
 
 exports.double = function (n) {

--- a/test/types.js
+++ b/test/types.js
@@ -96,4 +96,59 @@ describe('Types', function () {
     expect(utils.double('3.14')).to.equal(utils.float('3.14'))
     done()
   })
+
+  // int/float should never return NaN. The existing empty-string branch
+  // returns 0, but null/undefined/non-numeric input previously fell
+  // through to parseInt/parseFloat and produced NaN, corrupting
+  // downstream numeric fields with no signal.
+  it('Exports.int(null) should return 0', function (done) {
+    expect(utils.int(null)).to.equal(0)
+    done()
+  })
+
+  it('Exports.int(undefined) should return 0', function (done) {
+    expect(utils.int(undefined)).to.equal(0)
+    done()
+  })
+
+  it('Exports.int("abc") should return 0', function (done) {
+    expect(utils.int('abc')).to.equal(0)
+    done()
+  })
+
+  it('Exports.int(NaN) should return 0', function (done) {
+    expect(utils.int(NaN)).to.equal(0)
+    done()
+  })
+
+  it('Exports.float(null) should return 0', function (done) {
+    expect(utils.float(null)).to.equal(0)
+    done()
+  })
+
+  it('Exports.float(undefined) should return 0', function (done) {
+    expect(utils.float(undefined)).to.equal(0)
+    done()
+  })
+
+  it('Exports.float("abc") should return 0', function (done) {
+    expect(utils.float('abc')).to.equal(0)
+    done()
+  })
+
+  it('Exports.float(NaN) should return 0', function (done) {
+    expect(utils.float(NaN)).to.equal(0)
+    done()
+  })
+
+  // Regression: valid numeric input must still round-trip.
+  it('Exports.int("42") should return 42', function (done) {
+    expect(utils.int('42')).to.equal(42)
+    done()
+  })
+
+  it('Exports.float("3.14") should return 3.14', function (done) {
+    expect(utils.float('3.14')).to.equal(3.14)
+    done()
+  })
 })


### PR DESCRIPTION
## Summary

\`utils.int\` and \`utils.float\` have an empty-string fast path that returns \`0\`, but any other unparseable input (\`null\`, \`undefined\`, \`"abc"\`, \`NaN\`) falls through to \`parseInt\` / \`parseFloat\` and silently returns \`NaN\`.

Verified on current master:

\`\`\`
int(null)       -> NaN
int(undefined)  -> NaN
int("abc")      -> NaN
float(null)     -> NaN
\`\`\`

Every NMEA sentence parser in the ecosystem trusts \`int\`/\`float\` to return a number. A malformed field now produces a \`NaN\` signal-K value with no signal.

## Changes

Guard the \`parseInt\`/\`parseFloat\` result with \`Number.isNaN\` and return \`0\` / \`0.0\` on parse failure. The empty-string branch is unchanged.

## Test plan

- [x] 8 new tests for null/undefined/\"abc\"/NaN across both int and float — all fail on master, pass on this branch
- [x] 2 regression tests (int(\"42\") -> 42, float(\"3.14\") -> 3.14)
- [x] \`npm test\` — 71 passing (+10 new)
- [x] \`npm run prettier:check\` — clean