### PR TITLE
fix: zero() handles negative numbers correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,11 +296,14 @@
   }
 
   exports.zero = function (n) {
-    if (this.float(n) < 10) {
-      return '0' + n
-    } else {
-      return '' + n
+    var num = exports.float(n)
+    if (num < 0) {
+      return '-' + exports.zero(-num)
     }
+    if (num < 10) {
+      return '0' + n
+    }
+    return '' + n
   }
 
   exports.int = function (n) {

--- a/test/types.js
+++ b/test/types.js
@@ -32,4 +32,32 @@ describe('Types', function () {
     expect(utils.float('2.2')).to.be.equal(2.2)
     done()
   })
+
+  // zero() is a width-2 left-pad for non-negative numbers used by
+  // timestamp formatting. Previous implementation tested `n < 10` and
+  // blindly prefixed "0", which produced "0-5" for negatives.
+  it('Exports.zero(0) should equal "00"', function (done) {
+    expect(utils.zero(0)).to.equal('00')
+    done()
+  })
+
+  it('Exports.zero(9) should equal "09"', function (done) {
+    expect(utils.zero(9)).to.equal('09')
+    done()
+  })
+
+  it('Exports.zero(10) should equal "10"', function (done) {
+    expect(utils.zero(10)).to.equal('10')
+    done()
+  })
+
+  it('Exports.zero(-5) should equal "-05"', function (done) {
+    expect(utils.zero(-5)).to.equal('-05')
+    done()
+  })
+
+  it('Exports.zero(-15) should equal "-15"', function (done) {
+    expect(utils.zero(-15)).to.equal('-15')
+    done()
+  })
 })


### PR DESCRIPTION
## Summary

\`zero(-5)\` returns the nonsensical string \`"0-5"\`. The guard only tests \`n < 10\` and blindly prefixes \`"0"\`:

\`\`\`
zero(-5)    -> "0-5"
zero(-0.5)  -> "0-0.5"
\`\`\`

In practice \`zero()\` is a two-char left-pad used for hours/minutes/seconds in \`timestamp\` formatting, where inputs are always non-negative, so this never fires in the hot path. But \`zero\` is exported, and some callers may pass negative numbers (e.g. signed minutes or longitude degrees).

## Changes

Recurse on the absolute value and re-attach the sign on return. \`zero(-5)\` -> \`"-05"\`, \`zero(-15)\` -> \`"-15"\`.

## Test plan

- [x] 5 new tests (\`zero(0)\`, \`zero(9)\`, \`zero(10)\`, \`zero(-5)\`, \`zero(-15)\`) — the two negative ones fail on master
- [x] \`npm test\` — 66 passing
- [x] \`npm run prettier:check\` — clean