### PR TITLE
refactor: add magneticVariation as canonical alias for typo'd export

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@
 
   exports.magneticVariaton = function (degrees, pole) {
     pole = pole.toUpperCase()
-    degrees = this.float(degrees)
+    degrees = exports.float(degrees)
 
     if (pole == 'S' || pole == 'W') {
       degrees *= -1
@@ -219,6 +219,10 @@
 
     return degrees
   }
+
+  // Canonical spelling. `magneticVariaton` is a long-standing typo kept
+  // for backcompat; new code should prefer `magneticVariation`.
+  exports.magneticVariation = exports.magneticVariaton
 
   exports.timestamp = function (time, date) {
     /* TIME (UTC) */

--- a/test/magnetic_variation.js
+++ b/test/magnetic_variation.js
@@ -31,4 +31,27 @@ describe('Magnetic Variation', function () {
     expect(W).to.be.below(0)
     done()
   })
+
+  // The original export name 'magneticVariaton' is a long-standing typo.
+  // 'magneticVariation' is the canonical spelling; both should resolve
+  // to the same implementation for the lifetime of the deprecation.
+  it('magneticVariation is exported as an alias for magneticVariaton', function (done) {
+    expect(utils.magneticVariation).to.be.a('function')
+    expect(utils.magneticVariation).to.equal(utils.magneticVariaton)
+    done()
+  })
+
+  it('magneticVariation(1, "N") returns a positive number', function (done) {
+    var n = utils.magneticVariation(1, 'N')
+    expect(n).to.be.a('number')
+    expect(n).to.be.above(0)
+    done()
+  })
+
+  it('magneticVariation(1, "W") returns a negative number', function (done) {
+    var w = utils.magneticVariation(1, 'W')
+    expect(w).to.be.a('number')
+    expect(w).to.be.below(0)
+    done()
+  })
 })


### PR DESCRIPTION
## Summary

\`exports.magneticVariaton\` has been misspelled since the initial commit. Renaming outright would break every downstream consumer, so add \`exports.magneticVariation\` as an alias pointing at the same function. New code should prefer the canonical spelling; the typo'd name stays for backcompat.

Also swap the internal \`this.float(degrees)\` to \`exports.float(degrees)\` so the function works under destructuring (\`const { magneticVariaton } = utils\`), where \`this\` would be \`undefined\`.

## Test plan

- [x] New tests assert \`utils.magneticVariation === utils.magneticVariaton\` and exercise N/W via the canonical name
- [x] \`npm test\` — 64 passing (+3 new)
- [x] \`npm run prettier:check\` — clean