### PR TITLE
refactor: replace transform cascade with dispatch table

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,12 +101,21 @@
     // KM
     if (inputFormat == 'km') {
       if (outputFormat == 'nm') return value / utils.RATIOS.NM_IN_KM
+      if (outputFormat == 'm') return value * 1000
     }
 
     // NM
     if (inputFormat == 'nm') {
       if (outputFormat == 'km') return value / utils.RATIOS.KM_IN_NM
       if (outputFormat == 'm') return (value * 1000) / utils.RATIOS.KM_IN_NM
+    }
+
+    // M
+    if (inputFormat == 'm') {
+      if (outputFormat == 'km') return value / 1000
+      if (outputFormat == 'nm') return (value / 1000) * utils.RATIOS.KM_IN_NM
+      if (outputFormat == 'ft') return value * utils.RATIOS.METER_IN_FEET
+      if (outputFormat == 'fa') return value * utils.RATIOS.METER_IN_FATHOM
     }
 
     // KNOTS
@@ -146,8 +155,10 @@
       if (outputFormat == 'deg') return value / utils.RATIOS.DEG_IN_RAD
     }
 
+    // TEMPERATURE
     if (inputFormat == 'c') {
       if (outputFormat == 'k') return value + utils.RATIOS.CELSIUS_IN_KELVIN
+      if (outputFormat == 'f') return value * 1.8 + 32
     }
 
     if (inputFormat == 'k') {
@@ -157,9 +168,11 @@
     }
 
     if (inputFormat == 'f') {
+      if (outputFormat == 'c') return (value - 32) / 1.8
       if (outputFormat == 'k')
         return (value - 32) / 1.8 + utils.RATIOS.CELSIUS_IN_KELVIN
     }
+
     // LENGTH
     if (inputFormat == 'ft') {
       if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FEET
@@ -168,8 +181,10 @@
     if (inputFormat == 'fa') {
       if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FATHOM
     }
-    // Just return input if input/output formats are not recognised.
-    return value
+
+    throw new Error(
+      'unsupported conversion: ' + inputFormat + ' -> ' + outputFormat
+    )
   }
 
   exports.magneticVariaton = function (degrees, pole) {

--- a/index.js
+++ b/index.js
@@ -88,9 +88,111 @@
     }
   }
 
+  // Dispatch table: key = 'from:to', value = converter fn.
+  // Kept as a single source of truth so adding a new unit pair is
+  // one line here and a new test.
+  var CONVERSIONS = {
+    // Distance
+    'km:nm': function (v) {
+      return v / utils.RATIOS.NM_IN_KM
+    },
+    'km:m': function (v) {
+      return v * 1000
+    },
+    'nm:km': function (v) {
+      return v / utils.RATIOS.KM_IN_NM
+    },
+    'nm:m': function (v) {
+      return (v * 1000) / utils.RATIOS.KM_IN_NM
+    },
+    'm:km': function (v) {
+      return v / 1000
+    },
+    'm:nm': function (v) {
+      return (v / 1000) * utils.RATIOS.KM_IN_NM
+    },
+    'm:ft': function (v) {
+      return v * utils.RATIOS.METER_IN_FEET
+    },
+    'm:fa': function (v) {
+      return v * utils.RATIOS.METER_IN_FATHOM
+    },
+    'ft:m': function (v) {
+      return v / utils.RATIOS.METER_IN_FEET
+    },
+    'fa:m': function (v) {
+      return v / utils.RATIOS.METER_IN_FATHOM
+    },
+
+    // Speed
+    'knots:kph': function (v) {
+      return v / utils.RATIOS.KPH_IN_KNOTS
+    },
+    'knots:ms': function (v) {
+      return v / utils.RATIOS.MS_IN_KNOTS
+    },
+    'knots:mph': function (v) {
+      return v / utils.RATIOS.MPH_IN_KNOTS
+    },
+    'kph:knots': function (v) {
+      return v / utils.RATIOS.KNOTS_IN_KPH
+    },
+    'kph:ms': function (v) {
+      return v / utils.RATIOS.MS_IN_KPH
+    },
+    'kph:mph': function (v) {
+      return v / utils.RATIOS.MPH_IN_KPH
+    },
+    'mph:knots': function (v) {
+      return v / utils.RATIOS.KNOTS_IN_MPH
+    },
+    'mph:ms': function (v) {
+      return v / utils.RATIOS.MS_IN_MPH
+    },
+    'mph:kph': function (v) {
+      return v / utils.RATIOS.KPH_IN_MPH
+    },
+    'ms:knots': function (v) {
+      return v / utils.RATIOS.KNOTS_IN_MS
+    },
+    'ms:mph': function (v) {
+      return v / utils.RATIOS.MPH_IN_MS
+    },
+    'ms:kph': function (v) {
+      return v / utils.RATIOS.KPH_IN_MS
+    },
+
+    // Angle
+    'deg:rad': function (v) {
+      return v / utils.RATIOS.RAD_IN_DEG
+    },
+    'rad:deg': function (v) {
+      return v / utils.RATIOS.DEG_IN_RAD
+    },
+
+    // Temperature
+    'c:k': function (v) {
+      return v + utils.RATIOS.CELSIUS_IN_KELVIN
+    },
+    'c:f': function (v) {
+      return v * 1.8 + 32
+    },
+    'k:c': function (v) {
+      return v - utils.RATIOS.CELSIUS_IN_KELVIN
+    },
+    'k:f': function (v) {
+      return (v - utils.RATIOS.CELSIUS_IN_KELVIN) * 1.8 + 32
+    },
+    'f:c': function (v) {
+      return (v - 32) / 1.8
+    },
+    'f:k': function (v) {
+      return (v - 32) / 1.8 + utils.RATIOS.CELSIUS_IN_KELVIN
+    }
+  }
+
   exports.transform = function (value, inputFormat, outputFormat) {
     value = exports.float(value)
-
     inputFormat = inputFormat.toLowerCase()
     outputFormat = outputFormat.toLowerCase()
 
@@ -98,93 +200,13 @@
       return value
     }
 
-    // KM
-    if (inputFormat == 'km') {
-      if (outputFormat == 'nm') return value / utils.RATIOS.NM_IN_KM
-      if (outputFormat == 'm') return value * 1000
+    var converter = CONVERSIONS[inputFormat + ':' + outputFormat]
+    if (!converter) {
+      throw new Error(
+        'unsupported conversion: ' + inputFormat + ' -> ' + outputFormat
+      )
     }
-
-    // NM
-    if (inputFormat == 'nm') {
-      if (outputFormat == 'km') return value / utils.RATIOS.KM_IN_NM
-      if (outputFormat == 'm') return (value * 1000) / utils.RATIOS.KM_IN_NM
-    }
-
-    // M
-    if (inputFormat == 'm') {
-      if (outputFormat == 'km') return value / 1000
-      if (outputFormat == 'nm') return (value / 1000) * utils.RATIOS.KM_IN_NM
-      if (outputFormat == 'ft') return value * utils.RATIOS.METER_IN_FEET
-      if (outputFormat == 'fa') return value * utils.RATIOS.METER_IN_FATHOM
-    }
-
-    // KNOTS
-    if (inputFormat == 'knots') {
-      if (outputFormat == 'kph') return value / utils.RATIOS.KPH_IN_KNOTS
-      if (outputFormat == 'ms') return value / utils.RATIOS.MS_IN_KNOTS
-      if (outputFormat == 'mph') return value / utils.RATIOS.MPH_IN_KNOTS
-    }
-
-    // KPH
-    if (inputFormat == 'kph') {
-      if (outputFormat == 'knots') return value / utils.RATIOS.KNOTS_IN_KPH
-      if (outputFormat == 'ms') return value / utils.RATIOS.MS_IN_KPH
-      if (outputFormat == 'mph') return value / utils.RATIOS.MPH_IN_KPH
-    }
-
-    // MPH
-    if (inputFormat == 'mph') {
-      if (outputFormat == 'knots') return value / utils.RATIOS.KNOTS_IN_MPH
-      if (outputFormat == 'ms') return value / utils.RATIOS.MS_IN_MPH
-      if (outputFormat == 'kph') return value / utils.RATIOS.KPH_IN_MPH
-    }
-
-    // MS
-    if (inputFormat == 'ms') {
-      if (outputFormat == 'knots') return value / utils.RATIOS.KNOTS_IN_MS
-      if (outputFormat == 'mph') return value / utils.RATIOS.MPH_IN_MS
-      if (outputFormat == 'kph') return value / utils.RATIOS.KPH_IN_MS
-    }
-
-    // ANGLES
-    if (inputFormat == 'deg') {
-      if (outputFormat == 'rad') return value / utils.RATIOS.RAD_IN_DEG
-    }
-
-    if (inputFormat == 'rad') {
-      if (outputFormat == 'deg') return value / utils.RATIOS.DEG_IN_RAD
-    }
-
-    // TEMPERATURE
-    if (inputFormat == 'c') {
-      if (outputFormat == 'k') return value + utils.RATIOS.CELSIUS_IN_KELVIN
-      if (outputFormat == 'f') return value * 1.8 + 32
-    }
-
-    if (inputFormat == 'k') {
-      if (outputFormat == 'c') return value - utils.RATIOS.CELSIUS_IN_KELVIN
-      if (outputFormat == 'f')
-        return (value - utils.RATIOS.CELSIUS_IN_KELVIN) * 1.8 + 32
-    }
-
-    if (inputFormat == 'f') {
-      if (outputFormat == 'c') return (value - 32) / 1.8
-      if (outputFormat == 'k')
-        return (value - 32) / 1.8 + utils.RATIOS.CELSIUS_IN_KELVIN
-    }
-
-    // LENGTH
-    if (inputFormat == 'ft') {
-      if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FEET
-    }
-
-    if (inputFormat == 'fa') {
-      if (outputFormat == 'm') return value / utils.RATIOS.METER_IN_FATHOM
-    }
-
-    throw new Error(
-      'unsupported conversion: ' + inputFormat + ' -> ' + outputFormat
-    )
+    return converter(value)
   }
 
   exports.magneticVariaton = function (degrees, pole) {

--- a/test/transform.js
+++ b/test/transform.js
@@ -225,4 +225,88 @@ describe('Transform', function () {
     expect(value).to.equal(18.288222384784202)
     done()
   })
+
+  // Celsius <-> Fahrenheit (previously missing — transform silently
+  // returned the input unchanged).
+  it('CELSIUS -> FAHRENHEIT (water freezing)', function (done) {
+    var value = utils.transform(0, 'c', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(32, 1e-9)
+    done()
+  })
+
+  it('CELSIUS -> FAHRENHEIT (water boiling)', function (done) {
+    var value = utils.transform(100, 'c', 'f')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(212, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> CELSIUS (water freezing)', function (done) {
+    var value = utils.transform(32, 'f', 'c')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(0, 1e-9)
+    done()
+  })
+
+  it('FAHRENHEIT -> CELSIUS (water boiling)', function (done) {
+    var value = utils.transform(212, 'f', 'c')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(100, 1e-9)
+    done()
+  })
+
+  // Distance base-unit pairs that were missing.
+  it('KM -> M', function (done) {
+    expect(utils.transform(1, 'km', 'm')).to.equal(1000)
+    done()
+  })
+
+  it('M -> KM', function (done) {
+    expect(utils.transform(1000, 'm', 'km')).to.equal(1)
+    done()
+  })
+
+  it('M -> NM', function (done) {
+    var value = utils.transform(1852, 'm', 'nm')
+    expect(value).to.be.closeTo(1, 1e-6)
+    done()
+  })
+
+  // Length: the inverse of the existing ft -> m / fa -> m pairs.
+  it('METERS -> FEET', function (done) {
+    var value = utils.transform(1, 'm', 'ft')
+    expect(value).to.be.closeTo(3.2808, 1e-4)
+    done()
+  })
+
+  it('METERS -> FATHOMS', function (done) {
+    var value = utils.transform(1, 'm', 'fa')
+    expect(value).to.be.closeTo(0.5468, 1e-4)
+    done()
+  })
+
+  // Unknown conversions must fail loudly. Previously transform silently
+  // returned the input for any unrecognised pair, giving callers wrong
+  // values with no signal.
+  it('throws on unknown input unit', function (done) {
+    expect(function () {
+      utils.transform(1, 'furlong', 'm')
+    }).to.throw(/unsupported conversion/i)
+    done()
+  })
+
+  it('throws on unknown output unit', function (done) {
+    expect(function () {
+      utils.transform(1, 'm', 'furlong')
+    }).to.throw(/unsupported conversion/i)
+    done()
+  })
+
+  it('throws on typo (kmh instead of kph)', function (done) {
+    expect(function () {
+      utils.transform(10, 'knots', 'kmh')
+    }).to.throw(/unsupported conversion/i)
+    done()
+  })
 })


### PR DESCRIPTION
## Summary

Stacks on top of #39 — please merge #39 first so this PR collapses to the pure refactor.

The \`exports.transform\` cascade has grown to ~100 lines of branches where each inner branch just computes \`value / RATIOS.X_IN_Y\`. Replace it with a single \`CONVERSIONS\` map keyed by \`'from:to'\` plus a one-line lookup in the entry point.

## Changes

- Replace the cascade with a flat dispatch table of ~30 entries.
- Entry point: \`.toLowerCase()\` both sides, skip same-unit fast path, look up \`from:to\` in the map, throw if absent.

## Behavior (unchanged)

All 73 tests pass unmodified, including the same-unit fast path, the missing-pair additions from #39, and the throw-on-unknown cases. Math goes through the same \`RATIOS\` constants and returns the same values.

## Benefits

- Adding a new unit pair is one line + one test
- Dispatch table is the single source of truth for supported conversions
- O(1) lookup

## Test plan

- [x] \`npm test\` — 73 passing (no new tests, pure refactor)
- [x] \`npm run prettier:check\` — clean