### PR TITLE
test: backfill coverage for edge cases and underexercised paths

### DIFF
--- a/test/checksum.js
+++ b/test/checksum.js
@@ -62,4 +62,24 @@ describe('CheckSum', function () {
     expect(utils.valid(sentence4, false)).to.equal(true)
     done()
   })
+
+  // valid() edge cases that weren't covered.
+  it('empty string is not valid', function (done) {
+    expect(utils.valid('', true)).to.equal(false)
+    expect(utils.valid('   ', true)).to.equal(false)
+    done()
+  })
+
+  it('sentence without $ or ! prefix is not valid', function (done) {
+    expect(
+      utils.valid('GPGGA,000000.00,5253.164,N,00539.655,E,0,00,99.9,,M,,M,,*6F')
+    ).to.equal(false)
+    done()
+  })
+
+  it('validateChecksum defaults to true when omitted', function (done) {
+    // sentence4 has an invalid checksum; default should reject.
+    expect(utils.valid(sentence4)).to.equal(false)
+    done()
+  })
 })

--- a/test/coordinate.js
+++ b/test/coordinate.js
@@ -21,4 +21,29 @@ describe('Coordinate', function () {
     expect(W).to.equal(-4.909706666666667)
     done()
   })
+
+  // Single-digit-degree latitude: "454.5824" is 4°54.5824' E.
+  it('single-digit degree latitude is parsed correctly', function (done) {
+    expect(utils.coordinate('454.5824', 'E')).to.equal(4.909706666666667)
+    done()
+  })
+
+  // Null Island: both lat and lon are 0.
+  it('handles zero coordinates (Null Island)', function (done) {
+    expect(utils.coordinate('0.0', 'N')).to.equal(0)
+    expect(utils.coordinate('0.0', 'E')).to.equal(0)
+    done()
+  })
+
+  // Equatorial non-zero longitude.
+  it('E near equator: 10000.0000 -> 100°00.0000', function (done) {
+    expect(utils.coordinate('10000.0000', 'E')).to.equal(100)
+    done()
+  })
+
+  // Southern hemisphere produces a negative value.
+  it('S pole flips sign', function (done) {
+    expect(utils.coordinate('5222.3277', 'S')).to.equal(-52.372128333333336)
+    done()
+  })
 })

--- a/test/timestamp.js
+++ b/test/timestamp.js
@@ -31,4 +31,23 @@ describe('Timestamp', function () {
     expect(value).to.equal(expected)
     done()
   })
+
+  // Pin the current subsecond-truncation behavior. NMEA time fields carry
+  // hundredths (e.g. "173456.75"), but `time.slice(4, 6)` only picks up
+  // the integer seconds. The ISO output reports whole seconds with .000
+  // milliseconds. If a future change starts preserving hundredths, this
+  // test will fail and force a conscious decision.
+  it('truncates fractional seconds (documents current behavior)', function (done) {
+    const value = utils.timestamp('173456.75', '050426')
+    expect(value).to.equal('2026-04-05T17:34:56.000Z')
+    done()
+  })
+
+  it('passing only time uses todays UTC date', function (done) {
+    const today = new Date().toISOString().slice(0, 10)
+    const value = utils.timestamp('120000', null)
+    expect(value.slice(0, 10)).to.equal(today)
+    expect(value.slice(11, 19)).to.equal('12:00:00')
+    done()
+  })
 })

--- a/test/transform.js
+++ b/test/transform.js
@@ -17,6 +17,13 @@ describe('Transform', function () {
     done()
   })
 
+  it('NM -> M', function (done) {
+    var value = utils.transform(1, 'nm', 'm')
+    expect(value).to.be.a('number')
+    expect(value).to.be.closeTo(1852, 1e-3)
+    done()
+  })
+
   // KTS
   it('KTS -> KPH', function (done) {
     var value = utils.transform(1, 'knots', 'kph')
@@ -307,6 +314,20 @@ describe('Transform', function () {
     expect(function () {
       utils.transform(10, 'knots', 'kmh')
     }).to.throw(/unsupported conversion/i)
+    done()
+  })
+
+  // Same-unit fast path and mixed-case unit strings.
+  it('same-unit fast path returns the numeric value unchanged', function (done) {
+    expect(utils.transform(42, 'm', 'm')).to.equal(42)
+    expect(utils.transform('42.5', 'knots', 'knots')).to.equal(42.5)
+    done()
+  })
+
+  it('accepts uppercase unit strings', function (done) {
+    expect(utils.transform(1, 'KNOTS', 'MS')).to.equal(
+      utils.transform(1, 'knots', 'ms')
+    )
     done()
   })
 })

--- a/test/types.js
+++ b/test/types.js
@@ -60,4 +60,40 @@ describe('Types', function () {
     expect(utils.zero(-15)).to.equal('-15')
     done()
   })
+
+  // zero() handles the n >= 10 branch (no leading zero).
+  it('Exports.zero(42) should return "42" without padding', function (done) {
+    expect(utils.zero(42)).to.equal('42')
+    done()
+  })
+
+  it('Exports.zero(100) should return "100" without padding', function (done) {
+    expect(utils.zero(100)).to.equal('100')
+    done()
+  })
+
+  // The empty-string / whitespace path in int/float — previously only
+  // exercised through higher-level timestamp parsing.
+  it('int returns 0 for empty string and whitespace', function (done) {
+    expect(utils.int('')).to.equal(0)
+    expect(utils.int('  ')).to.equal(0)
+    done()
+  })
+
+  it('float returns 0 for empty string and whitespace', function (done) {
+    expect(utils.float('')).to.equal(0)
+    expect(utils.float('  ')).to.equal(0)
+    done()
+  })
+
+  // Alias coverage: integer / double mirror int / float.
+  it('integer is an alias for int', function (done) {
+    expect(utils.integer('42')).to.equal(utils.int('42'))
+    done()
+  })
+
+  it('double is an alias for float', function (done) {
+    expect(utils.double('3.14')).to.equal(utils.float('3.14'))
+    done()
+  })
 })


### PR DESCRIPTION
## Summary

Pins existing behaviour that wasn't tested so future changes get a clear signal if they shift. Zero source-code changes; 18 new tests, all passing on master.

## Coverage

Before: \`95.17\` stmts / \`88.75\` branch / \`92.85\` func
After:  \`99.31\` stmts / \`97.77\` branch / \`100\` func

Only lines still uncovered are \`171-172\` — the silent-fallback \`return value\` at the end of \`transform\` — which is being replaced with a thrown \`Error\` in #39.

## What's covered

**\`transform\`:**
- Same-unit fast path returns input unchanged
- Uppercase unit strings (lowercased internally)
- \`nm → m\` (was the one missing statement on the happy path)

**\`coordinate\`:**
- Single-digit degree latitude (\`454.5824\` → \`4.909...\`)
- Null Island (\`0.0\` N / \`0.0\` E)
- \`10000.0000\` E → exactly 100 degrees
- S pole flips sign

**\`timestamp\`:**
- Pins current fractional-second truncation behaviour (\`'173456.75'\` → \`:56.000Z\`). Flagged as a minor correctness issue during review; this pinning forces a conscious decision if a fix is attempted later.
- Time-only call uses today's UTC date

**\`valid\`:**
- Empty string / whitespace rejected
- Sentence without \`$\`/\`!\` prefix rejected
- \`validateChecksum\` defaults to \`true\` when omitted

**\`int\`/\`float\`/\`zero\`/\`integer\`/\`double\`:**
- Empty / whitespace returns 0
- \`integer\` is an alias for \`int\`, \`double\` is an alias for \`float\`
- \`zero(42)\` / \`zero(100)\` — no padding branch

## Test plan

- [x] \`npm test\` — 79 passing (+18 new)
- [x] \`npm run coverage\` — 99.31 stmts, 97.77 branch, 100 func
- [x] \`npm run prettier:check\` — clean