### PR TITLE
docs: use scoped package name in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Various utilities for transforming NMEA0183 units into SI units for use in Signa
 
 # Installation
 
-`npm install nmea0183-utilities`
+`npm install @signalk/nmea0183-utilities`
 
 # Some examples
 
 ```javascript
-var utils = require('nmea0183-utilities')
+var utils = require('@signalk/nmea0183-utilities')
 
 // Transform 3 knots into m/s
 var ms = utils.transform(3, 'knots', 'ms')


### PR DESCRIPTION
## Summary
- Fix install command and `require()` example in README to use the scoped name `@signalk/nmea0183-utilities` (matches `package.json`).

Fixes #49

## Test plan
- [x] `npm run prettier:check` passes