### PR TITLE
fix: preserve milliseconds in timestamp() (#36)

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,17 +162,26 @@ exports.magneticVariation = exports.magneticVariaton
 
 exports.timestamp = function (time, date) {
   /* TIME (UTC) */
-  let hours, minutes, seconds, year, month, day
+  let hours, minutes, seconds, milliseconds, year, month, day
 
   if (time) {
     hours = exports.int(time.slice(0, 2))
     minutes = exports.int(time.slice(2, 4))
     seconds = exports.int(time.slice(4, 6))
+    // NMEA time may carry a fractional tail (e.g. u-blox 10 Hz fixes arrive
+    // as '173456.75'). Capture up to 3 digits after the dot, right-padded,
+    // so '.2' -> 200, '.25' -> 250, '.2567' -> 256. Missing or non-digit
+    // tails degrade to 0 ms (keeps malformed-sentence handling unchanged).
+    const fraction = /\.(\d+)/.exec(time)
+    milliseconds = fraction
+      ? parseInt((fraction[1] + '000').slice(0, 3), 10)
+      : 0
   } else {
     const dt = new Date()
     hours = dt.getUTCHours()
     minutes = dt.getUTCMinutes()
     seconds = dt.getUTCSeconds()
+    milliseconds = 0
   }
 
   /* DATE (UTC) */
@@ -188,7 +197,9 @@ exports.timestamp = function (time, date) {
   }
 
   /* construct */
-  const d = new Date(Date.UTC(year, month - 1, day, hours, minutes, seconds)) // month is expected to be 0-11
+  const d = new Date(
+    Date.UTC(year, month - 1, day, hours, minutes, seconds, milliseconds)
+  ) // month is expected to be 0-11
   return d.toISOString()
 }
 

--- a/test/timestamp.js
+++ b/test/timestamp.js
@@ -32,13 +32,35 @@ describe('Timestamp', function () {
     done()
   })
 
-  // Pin the current subsecond-truncation behavior. NMEA time fields carry
-  // hundredths (e.g. "173456.75"), but `time.slice(4, 6)` only picks up
-  // the integer seconds. The ISO output reports whole seconds with .000
-  // milliseconds. If a future change starts preserving hundredths, this
-  // test will fail and force a conscious decision.
-  it('truncates fractional seconds (documents current behavior)', function (done) {
+  // NMEA time fields may carry a fractional tail (e.g. "173456.75" = 750 ms).
+  // Fix for SignalK/nmea0183-utilities#36 — previously the tail was dropped
+  // and output always ended in .000Z.
+  it('preserves fractional seconds as milliseconds', function (done) {
     const value = utils.timestamp('173456.75', '050426')
+    expect(value).to.equal('2026-04-05T17:34:56.750Z')
+    done()
+  })
+
+  it('right-pads a single fractional digit (.2 -> 200 ms)', function (done) {
+    const value = utils.timestamp('173456.2', '050426')
+    expect(value).to.equal('2026-04-05T17:34:56.200Z')
+    done()
+  })
+
+  it('truncates beyond millisecond precision (.2567 -> 256 ms)', function (done) {
+    const value = utils.timestamp('173456.2567', '050426')
+    expect(value).to.equal('2026-04-05T17:34:56.256Z')
+    done()
+  })
+
+  it('treats a non-digit fractional tail as 0 ms', function (done) {
+    const value = utils.timestamp('173456.abc', '050426')
+    expect(value).to.equal('2026-04-05T17:34:56.000Z')
+    done()
+  })
+
+  it('treats an empty fractional tail as 0 ms', function (done) {
+    const value = utils.timestamp('173456.', '050426')
     expect(value).to.equal('2026-04-05T17:34:56.000Z')
     done()
   })


### PR DESCRIPTION
Closes #36.

## Summary

- `exports.timestamp` now parses an optional `.digits` tail on the time field and passes it to `Date.UTC` as the 7th argument
- 3-digit truncation with right-pad: `'.2'` → 200 ms, `'.25'` → 250 ms, `'.2567'` → 256 ms
- Missing or non-digit tails fall through to 0 ms so malformed-sentence handling is unchanged
- Existing `.000Z` output is preserved whenever the source has no fraction

## Motivation

NMEA sentences from GNSS receivers running faster than 1 Hz (u-blox 5/10 Hz, etc.) carry sub-second precision. `time.slice(4, 6)` was dropping it, so every ISO timestamp emitted by this util ended in `.000Z`. Downstream consumers were left to bypass the util (see `nmea0183-signalk/hooks/ZDA.js` which computes ms manually).

The SignalK spec defines `timestamp` as RFC 3339 with pattern `.*Z$` — a fractional ISO like `2026-04-05T17:34:56.750Z` validates cleanly, no schema change needed.

## Blast-radius check

In-org consumers of `utils.timestamp` (all in `nmea0183-signalk`): `GGA`, `GLL`, `BWC`, `BWR`, `GNS`, `RMC`. All pass the ISO string straight through as delta `timestamp`. `RMC` additionally does `Math.floor(Date.parse(ts) / 1000)` — `Date.parse` handles fractional ISO fine, so `age` math is unaffected. `signalk-server/packages/streams` only imports `appendChecksum`. No public GitHub consumer calls `.timestamp()` on this package.

Downstream risk is limited to anyone doing strict string equality on `.000Z`, which is why this is worth a **minor** bump (0.11.x → 0.12.0) rather than patch, with a changelog line flagging the behavior change.

## Test plan

- [x] `npm test` (126 passing, up from 122 — added 5 positive/edge-case assertions, removed the one pin that documented the old truncation)
- [x] `npm run coverage` — 100% lines / branches / funcs / stmts on `index.js`
- [x] `npm run prettier:check` — clean
- [x] `npm run mutate` — 98.82% (same 3 pre-existing equivalent-mutant survivors in `checksum` / `magneticVariaton` / `coordinate`, unchanged from baseline 98.80% on master); all new mutants in the changed region killed

## Follow-up (separate PR against `nmea0183-signalk`)

- Drop the inline `(parts[0].substring(4) % 1) * 1000` workaround in `hooks/ZDA.js` once this ships and the package is bumped downstream.