### PR TITLE
chore: add Stryker mutation testing, align with signalk-derived-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha",
     "coverage": "c8 --reporter=text --reporter=lcov npm test",
-    "mutate": "stryker run",
+    "mutation": "stryker run",
     "prettier:check": "prettier --check .",
     "prettier": "prettier --write .",
     "format": "npm run prettier"

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "npm",
+  "reporters": ["clear-text", "progress", "html"],
+  "testRunner": "mocha",
+  "mochaOptions": {
+    "spec": ["test/**/*.js"]
+  },
+  "coverageAnalysis": "perTest",
+  "mutate": ["index.js"],
+  "thresholds": {
+    "high": 90,
+    "low": 80,
+    "break": 0
+  },
+  "disableTypeChecks": false,
+  "ignorePatterns": [
+    "coverage",
+    "reports",
+    ".stryker-tmp",
+    "node_modules/.cache"
+  ],
+  "timeoutMS": 30000
+}


### PR DESCRIPTION
## What

Bring the Stryker mutation-testing setup in line with `signalk-derived-data`, which is the role model for the family.

## Why

`signalk-derived-data` already ships `stryker.conf.json` + a `mutation` npm script. This repo had Stryker listed in `devDependencies` and a `mutate` script, but no config file — so `npm run mutate` fails today. Two small fixes to close the gap and align the command name.

## Changes

- **Add `stryker.conf.json`** — mocha runner, `perTest` coverage, mutate `index.js`, 30 s timeout, thresholds `high: 90 / low: 80 / break: 0`. Identical to `signalk-derived-data/stryker.conf.json` except for the per-repo `mutate` glob (this repo only has `index.js`).
- **Rename the existing script `mutate` → `mutation`** so every repo in the family uses the same command. `signalk-derived-data` uses `mutation`; this was the outlier.

No dep changes — `@stryker-mutator/core ^9.6.1` and `@stryker-mutator/mocha-runner ^9.6.1` were already in `devDependencies`.

## Verification

- `npm ci` succeeds.
- `npm test` — 126 / 126 passing.
- `stryker.conf.json` is valid JSON.
- `npx stryker --help` is callable (binary installed).
- Full mutation run not executed in this PR (takes minutes on the current suite). Once merged, `npm run mutation` should produce a baseline score we can use to raise the `break` threshold above 0 in a follow-up.

## Breakage risk

None. Config-only addition + one script rename. The rename is breaking only if something external calls `npm run mutate` on this repo — I couldn't find any such caller in the family; the role-model already settled on `mutation`.
