### PR TITLE
feat: add null-preserving intOrNull / floatOrNull / transformOrNull / magneticVariationOrNull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.1.0
+
+### Non-breaking additions
+
+- **`intOrNull(n)` / `floatOrNull(n)`** — null-preserving variants of
+  `int` / `float`. Return `null` for empty / whitespace / `null` /
+  `undefined` / non-numeric input, instead of silently coercing to `0`.
+  `intOrNull('0')` still returns `0`, so legitimate zero measurements
+  stay distinguishable from "not available".
+- **`transformOrNull(value, from, to)`** — null-short-circuiting unit
+  conversion. Identical to `transform` for real input; returns `null`
+  when `value` doesn't parse. Unsupported unit pairs still throw.
+- **`magneticVariationOrNull(degrees, pole)`** — null-preserving
+  magnetic variation. Returns `null` when degrees or pole is missing or
+  unparseable (including lowercase / unknown pole letters), rather than
+  throwing or returning `0`.
+
+Motivation: IEC 61162-1 §7.2.3.4 defines a null NMEA field as "sensor
+working, value not available" — distinct from a legitimate zero. Legacy
+`int` / `float` collapse both into `0`, which has caused bugs like
+SignalK/nmea0183-signalk#192 (magnetic variation reported as 0° from an
+empty RMC field, causing a 13° error in one reporter's case). Use the
+`*OrNull` family when passing through to Signal K, which maps `null` in
+a delta value onto the same semantic.
+
+Existing `int` / `float` / `transform` / `magneticVariation` are
+unchanged for back-compat.
+
 ## 1.0.0
 
 First stable release. The package is now authored in TypeScript with strict

--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ doesn't parse. Accepts `unknown` so `int(null)`, `int(undefined)`,
 Same idea for `parseFloat`. Accepts numbers or numeric strings. Returns
 `0.0` on parse failure.
 
+#### `intOrNull(n) => number | null` / `floatOrNull(n) => number | null`
+
+Null-preserving variants of `int` / `float`. An NMEA 0183 null field
+(IEC 61162-1 §7.2.3.4) signals "sensor working, value not available"
+and must not be confused with a legitimate zero. `intOrNull('')`,
+`intOrNull(null)`, `intOrNull('abc')` all return `null`; `intOrNull('0')`
+returns `0`. Prefer these over `int`/`float` when the caller wants to
+pass the not-available semantic through to Signal K (which treats `null`
+the same way).
+
+#### `transformOrNull(value, from, to) => number | null`
+
+Null-short-circuiting unit conversion. Identical to `transform` for real
+input; returns `null` when `value` is empty / `null` / `undefined` /
+non-numeric. Unsupported unit pairs still throw — the null short-circuit
+runs first, so a missing field with an unknown unit pair is still
+`null`, not an error.
+
+#### `magneticVariationOrNull(degrees, pole) => number | null`
+
+Null-preserving magnetic variation. Returns `null` when degrees or pole
+is missing or unparseable (including unknown / lowercase pole letters),
+rather than throwing or silently returning `0`. `0` with a valid pole
+returns `0`, not `null`.
+
 #### `zero(n) => string`
 
 Width-2 left-pad for integer date/time components. `zero(2) === '02'`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signalk/nmea0183-utilities",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@signalk/nmea0183-utilities",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/nmea0183-utilities",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Various utilities for transforming NMEA0183 units into SI units for use in SK.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,6 +345,74 @@ export function float(n: unknown): number {
   return Number.isNaN(parsed) ? 0.0 : parsed
 }
 
+// Null-preserving numeric parsers. An NMEA 0183 null field (IEC 61162-1
+// §7.2.3.4) signals "sensor working, value not available" and must not be
+// conflated with a legitimate zero. `int`/`float` above coerce to 0 for
+// back-compat; prefer these when the caller wants to preserve the
+// not-available semantic end-to-end.
+//
+//   intOrNull('')    -> null
+//   intOrNull('42')  -> 42
+//   intOrNull('abc') -> null
+export function intOrNull(n: unknown): number | null {
+  const parsed = parseInt(n as string, 10)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export function floatOrNull(n: unknown): number | null {
+  const parsed = parseFloat(n as string)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+// Null-short-circuiting unit conversion. Lets callers write
+//   transformOrNull(parts[8], 'deg', 'rad')
+// for an optional NMEA field without a surrounding emptiness check.
+// Unsupported conversion pairs still throw (same contract as `transform`).
+export function transformOrNull(
+  value: unknown,
+  inputFormat: UnitFormat,
+  outputFormat: UnitFormat
+): number | null {
+  const numeric = floatOrNull(value)
+  if (numeric === null) {
+    return null
+  }
+  if (inputFormat === outputFormat) {
+    return numeric
+  }
+  const converter = CONVERSIONS[inputFormat + ':' + outputFormat]
+  if (!converter) {
+    throw new Error(
+      'unsupported conversion: ' + inputFormat + ' -> ' + outputFormat
+    )
+  }
+  return converter(numeric)
+}
+
+// Null-preserving magnetic variation. Returns null when either the
+// degrees field or the pole letter is missing or unparseable, rather
+// than throwing or (via the old `float` path) silently returning 0.
+// Valid pole letters still enforce the `Pole` contract; an unknown
+// pole given alongside numeric degrees is treated as "not available"
+// rather than fatal, matching how callers already treat the whole
+// field as optional when the direction indicator is empty.
+export function magneticVariationOrNull(
+  degrees: unknown,
+  pole: unknown
+): number | null {
+  const deg = floatOrNull(degrees)
+  if (deg === null) {
+    return null
+  }
+  if (pole === 'N' || pole === 'E') {
+    return deg
+  }
+  if (pole === 'S' || pole === 'W') {
+    return -deg
+  }
+  return null
+}
+
 // Default export aggregate so ESM consumers using
 // `import utils from '@signalk/nmea0183-utilities'` get the same bag
 // that `const utils = require(...)` returns in CJS.
@@ -360,5 +428,9 @@ export default {
   isValidPosition,
   zero,
   int,
-  float
+  float,
+  intOrNull,
+  floatOrNull,
+  transformOrNull,
+  magneticVariationOrNull
 }

--- a/test/default_export.ts
+++ b/test/default_export.ts
@@ -18,6 +18,12 @@ describe('default export', function () {
     expect(utils.zero).to.equal(named.zero)
     expect(utils.int).to.equal(named.int)
     expect(utils.float).to.equal(named.float)
+    expect(utils.intOrNull).to.equal(named.intOrNull)
+    expect(utils.floatOrNull).to.equal(named.floatOrNull)
+    expect(utils.transformOrNull).to.equal(named.transformOrNull)
+    expect(utils.magneticVariationOrNull).to.equal(
+      named.magneticVariationOrNull
+    )
     done()
   })
 

--- a/test/or_null.ts
+++ b/test/or_null.ts
@@ -1,0 +1,212 @@
+import { expect } from 'chai'
+import * as utils from '../src/index'
+import type { UnitFormat } from '../src/index'
+
+// The `*OrNull` family preserves the IEC 61162-1 §7.2.3.4 "null field"
+// semantic: an empty NMEA field means "sensor working, value not
+// available" and must not be coerced to 0. Legacy `int`/`float` still
+// coerce, so downstream consumers that want the distinction must opt
+// in via these helpers.
+describe('intOrNull / floatOrNull', function () {
+  it('intOrNull("") returns null', function () {
+    expect(utils.intOrNull('')).to.equal(null)
+  })
+
+  it('intOrNull("  ") returns null (whitespace)', function () {
+    expect(utils.intOrNull('  ')).to.equal(null)
+  })
+
+  it('intOrNull(null) returns null', function () {
+    expect(utils.intOrNull(null)).to.equal(null)
+  })
+
+  it('intOrNull(undefined) returns null', function () {
+    expect(utils.intOrNull(undefined)).to.equal(null)
+  })
+
+  it('intOrNull("abc") returns null (non-numeric)', function () {
+    expect(utils.intOrNull('abc')).to.equal(null)
+  })
+
+  it('intOrNull(NaN) returns null', function () {
+    expect(utils.intOrNull(NaN)).to.equal(null)
+  })
+
+  it('intOrNull("0") returns 0 (legitimate zero, not null)', function () {
+    expect(utils.intOrNull('0')).to.equal(0)
+  })
+
+  it('intOrNull("42") returns 42', function () {
+    expect(utils.intOrNull('42')).to.equal(42)
+  })
+
+  it('intOrNull("-7") returns -7', function () {
+    expect(utils.intOrNull('-7')).to.equal(-7)
+  })
+
+  // parseInt behaviour: leading digits parse, trailing garbage is ignored.
+  // That's the same as `int`, so `intOrNull` stays consistent.
+  it('intOrNull("12abc") returns 12 (parseInt leading-digits behaviour)', function () {
+    expect(utils.intOrNull('12abc')).to.equal(12)
+  })
+
+  it('floatOrNull("") returns null', function () {
+    expect(utils.floatOrNull('')).to.equal(null)
+  })
+
+  it('floatOrNull("  ") returns null', function () {
+    expect(utils.floatOrNull('  ')).to.equal(null)
+  })
+
+  it('floatOrNull(null) returns null', function () {
+    expect(utils.floatOrNull(null)).to.equal(null)
+  })
+
+  it('floatOrNull(undefined) returns null', function () {
+    expect(utils.floatOrNull(undefined)).to.equal(null)
+  })
+
+  it('floatOrNull("abc") returns null', function () {
+    expect(utils.floatOrNull('abc')).to.equal(null)
+  })
+
+  it('floatOrNull(NaN) returns null', function () {
+    expect(utils.floatOrNull(NaN)).to.equal(null)
+  })
+
+  it('floatOrNull("0") returns 0 (legitimate zero)', function () {
+    expect(utils.floatOrNull('0')).to.equal(0)
+  })
+
+  it('floatOrNull("0.0") returns 0', function () {
+    expect(utils.floatOrNull('0.0')).to.equal(0)
+  })
+
+  it('floatOrNull("-0.5") returns -0.5', function () {
+    expect(utils.floatOrNull('-0.5')).to.equal(-0.5)
+  })
+
+  it('floatOrNull("3.14") returns 3.14', function () {
+    expect(utils.floatOrNull('3.14')).to.equal(3.14)
+  })
+
+  it('floatOrNull("1.5e2") returns 150 (scientific notation)', function () {
+    expect(utils.floatOrNull('1.5e2')).to.equal(150)
+  })
+
+  // Distinguishing 0 from missing is the whole point of this family.
+  it('0 is not confused with null (intOrNull)', function () {
+    const v = utils.intOrNull('0')
+    expect(v).to.equal(0)
+    expect(v).to.not.equal(null)
+  })
+
+  it('0 is not confused with null (floatOrNull)', function () {
+    const v = utils.floatOrNull('0')
+    expect(v).to.equal(0)
+    expect(v).to.not.equal(null)
+  })
+})
+
+describe('transformOrNull', function () {
+  it('short-circuits on empty input', function () {
+    expect(utils.transformOrNull('', 'deg', 'rad')).to.equal(null)
+  })
+
+  it('short-circuits on null', function () {
+    expect(utils.transformOrNull(null, 'knots', 'ms')).to.equal(null)
+  })
+
+  it('short-circuits on undefined', function () {
+    expect(utils.transformOrNull(undefined, 'nm', 'm')).to.equal(null)
+  })
+
+  it('short-circuits on non-numeric', function () {
+    expect(utils.transformOrNull('abc', 'deg', 'rad')).to.equal(null)
+  })
+
+  it('converts 0 (not confused with missing)', function () {
+    expect(utils.transformOrNull('0', 'deg', 'rad')).to.equal(0)
+  })
+
+  it('DEG -> RAD matches transform() for real input', function () {
+    expect(utils.transformOrNull(1, 'deg', 'rad')).to.equal(
+      utils.transform(1, 'deg', 'rad')
+    )
+  })
+
+  it('KNOTS -> MS matches transform() for real input', function () {
+    expect(utils.transformOrNull('10.5', 'knots', 'ms')).to.equal(
+      utils.transform('10.5', 'knots', 'ms')
+    )
+  })
+
+  it('same-unit fast path returns the numeric value unchanged', function () {
+    expect(utils.transformOrNull('42.5', 'ms', 'ms')).to.equal(42.5)
+  })
+
+  it('throws on unsupported conversion (same contract as transform)', function () {
+    expect(function () {
+      utils.transformOrNull(1, 'furlong' as UnitFormat, 'm')
+    }).to.throw(/unsupported conversion/i)
+  })
+
+  it('null input does NOT probe the converter table', function () {
+    // If the short-circuit were inverted, a null value with an unknown
+    // unit pair would throw instead of returning null.
+    expect(
+      utils.transformOrNull(
+        null,
+        'furlong' as UnitFormat,
+        'smoot' as UnitFormat
+      )
+    ).to.equal(null)
+  })
+})
+
+describe('magneticVariationOrNull', function () {
+  it('returns null on empty degrees', function () {
+    expect(utils.magneticVariationOrNull('', 'E')).to.equal(null)
+  })
+
+  it('returns null on empty pole', function () {
+    expect(utils.magneticVariationOrNull('3.1', '')).to.equal(null)
+  })
+
+  it('returns null on null degrees', function () {
+    expect(utils.magneticVariationOrNull(null, 'W')).to.equal(null)
+  })
+
+  it('returns null on unknown pole letter (instead of throwing)', function () {
+    // Unlike `magneticVariation`, the OrNull variant treats an unparseable
+    // pole as "not available" rather than fatal, matching how parsers
+    // already treat the whole variation field as optional.
+    expect(utils.magneticVariationOrNull('3.1', 'X')).to.equal(null)
+  })
+
+  it('returns null on lowercase pole letter (strict casing)', function () {
+    expect(utils.magneticVariationOrNull('3.1', 'e')).to.equal(null)
+  })
+
+  it('E returns positive degrees', function () {
+    expect(utils.magneticVariationOrNull('3.1', 'E')).to.equal(3.1)
+  })
+
+  it('N returns positive degrees', function () {
+    expect(utils.magneticVariationOrNull('3.1', 'N')).to.equal(3.1)
+  })
+
+  it('W negates degrees', function () {
+    expect(utils.magneticVariationOrNull('3.1', 'W')).to.equal(-3.1)
+  })
+
+  it('S negates degrees', function () {
+    expect(utils.magneticVariationOrNull('3.1', 'S')).to.equal(-3.1)
+  })
+
+  it('0 degrees with valid pole returns 0 (not null)', function () {
+    const v = utils.magneticVariationOrNull('0', 'E')
+    expect(v).to.equal(0)
+    expect(v).to.not.equal(null)
+  })
+})


### PR DESCRIPTION
## Summary

Adds four null-preserving numeric helpers so callers can distinguish a legitimate zero from an NMEA 0183 null field. Existing `int` / `float` / `transform` / `magneticVariation` are unchanged for back-compat.

## Motivation

IEC 61162-1 §7.2.3.4 defines a null NMEA field (`,,`) as *"sensor working, value not available"*. That is semantically distinct from a legitimate zero measurement. The existing `int` / `float` coerce both into numeric `0`, which manifests as real bugs downstream. For example [SignalK/nmea0183-signalk#192](https://github.com/SignalK/nmea0183-signalk/issues/192) — an empty RMC magnetic-variation field is parsed as `magneticVariation = 0`, causing a 13° course error for one reporter.

Signal K already uses `null` in a delta `value` to mean the same thing, so these helpers let parser hooks pass the not-available semantic through end-to-end.

## API

| New | Shape | Short-circuits on | Returns for `'0'` |
| --- | --- | --- | --- |
| `intOrNull(n)` | `unknown -> number \| null` | empty / whitespace / `null` / `undefined` / non-numeric | `0` |
| `floatOrNull(n)` | `unknown -> number \| null` | same | `0` |
| `transformOrNull(value, from, to)` | `(unknown, UnitFormat, UnitFormat) -> number \| null` | empty / `null` / `undefined` / non-numeric input; still throws on unsupported unit pair for real input | numeric conversion of 0 |
| `magneticVariationOrNull(degrees, pole)` | `(unknown, unknown) -> number \| null` | missing / unparseable degrees; unknown / lowercase pole | `0` for valid pole |

All four are exposed as named exports, wired into the default-export aggregate, and documented in the README.

## Scope

Strictly additive — no public API removed or changed. No bump to `engines` or dependencies.

## Test plan

- [x] `npm test` — 176/176 pass (42 new assertions in [test/or_null.ts](test/or_null.ts), plus additions to [test/default_export.ts](test/default_export.ts))
- [x] `npm run typecheck` — clean
- [x] `npm run prettier:check` — clean
- [x] `npm run build` — clean

## Release

Version bump to `1.1.0` (non-breaking additions). Ready to tag + release on merge; downstream consumer [SignalK/nmea0183-signalk](https://github.com/SignalK/nmea0183-signalk) will bump its dep in a follow-up PR (tracked against [#192](https://github.com/SignalK/nmea0183-signalk/issues/192)).